### PR TITLE
fix: harden reactive APIs and improve test coverage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,3 @@ _Put an `x` in the boxes that apply. You can also fill these out after creating 
 - [ ] Lint and unit tests pass locally with my changes
 - [ ] I have added tests that prove my fix is effective or that my feature works.
 - [ ] I have added necessary documentation (if appropriate).
-
-## Further comments
-
-If this is a relatively large or complex change add further comments on why you chose the solution you did and what alternatives you considered, etc...

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: canary
+          deno-version: v2.9.x
+
+      - name: Verify dependencies
+        run: deno ci
+
+      - name: Lint and format
+        run: deno task lint
+
+      - name: Type-check
+        run: deno task check
 
       - name: Test
         run: deno task test

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # Deno
-deno.lock
 .coverage
 .deno-docs
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,9 @@
   "[json]": {
     "editor.defaultFormatter": "denoland.vscode-deno"
   },
+  "[jsonc]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
   "[markdown]": {
     "editor.defaultFormatter": "denoland.vscode-deno"
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# Reactivity contributor instructions
+
+## Project overview
+
+This repository contains `@deft-plus/reactivity`, a Deno 2.9+ TypeScript library published to JSR. It implements fine-grained reactive signals, lazy memoized signals, asynchronous effects, promise-backed signals, and stores. Keep the library small, runtime-dependency-free, permission-conscious, and usable without a build step.
+
+The root `deno.jsonc` defines a workspace with two members:
+
+- `module/`: the publishable `@deft-plus/reactivity` package, implementation, public entry point, tests, and package README.
+- `docs/`: the long-form documentation pages and their front matter.
+
+The root `README.md` is a symlink to `module/README.md`. Edit `module/README.md`; do not replace the symlink with a separate copy. Files under `.agents/` and `skills-lock.json` are agent-tooling metadata, not library source.
+
+## Commands
+
+Run commands from the repository root.
+
+```bash
+deno ci                 # reproduce dependencies from deno.lock
+deno task fmt           # format source, configuration, and Markdown
+deno task lint          # lint and verify formatting
+deno task check         # type-check the public entry point and tests
+deno task test          # run tests and generate coverage
+deno task test:u        # run tests with the suite's update argument
+deno task jsdoc:lint    # validate public API documentation
+deno task jsdoc:generate
+deno publish --dry-run --allow-dirty
+```
+
+Before completing a code change, run `deno task lint`, `deno task check`, and `deno task test`. Run `deno task jsdoc:lint` when changing exported or protected APIs, and use a publish dry run when changing exports, package metadata, or published files.
+
+Do not grant `-A` to routine commands. Add the narrowest permission needed by the behavior under test.
+
+## Source and API conventions
+
+- `module/mod.ts` is the only public package entry point. Export intentional public APIs there; do not expose internal helpers accidentally.
+- Prefix internal implementation files with `_`, as in `_api.ts`, `_logging.ts`, and `_reactive_node.ts`.
+- Keep tests beside their implementation and name them `*_test.ts`.
+- Use explicit `.ts` extensions for relative imports and use import-map aliases for JSR dependencies.
+- Preserve strict TypeScript types. Avoid `any`, non-null assertions, unchecked casts, and broad `Function` types unless the mapping genuinely requires them and the lint suppression explains why.
+- Use two-space indentation, single quotes, 100-column TypeScript formatting, and Deno's formatter. Markdown uses `proseWrap: never`.
+- Add Apache-2.0 copyright headers to TypeScript source and test files.
+- Document public APIs with JSDoc, including behavior, parameters, returns, and a realistic example. Keep public signatures free of private referenced types so `deno doc --lint` succeeds.
+
+## Reactive implementation invariants
+
+- Reading a signal inside an active consumer records a dependency; `untracked()` must restore the previous consumer in a `finally` block.
+- Writable signals increment their value version and notify consumers only according to their equality/mutation contract.
+- Memoized signals remain lazy, cache values and errors, detect computation cycles, and avoid recomputation when dependency values are equivalent.
+- Effects are scheduled through the shared microtask queue and batch repeated notifications. Cleanup must run before re-execution and once on destruction.
+- Keep dependency edges weak and remove stale producer/consumer links. When changing graph bookkeeping, add tests for conditional dependencies, nested computations, cycles, batching, and cleanup.
+- A readonly wrapper must not expose mutation methods and must stay connected to the original writable signal.
+
+## Logging and permissions
+
+Logging precedence is part of the public contract:
+
+1. An explicit `{ log: true | false }` option wins.
+2. Otherwise, `SIGNAL_LOG=true` enables global logging only when the runtime grants access to that environment variable.
+3. Denied permissions, unavailable environment APIs, and non-Deno runtimes must safely default to logging disabled.
+
+Never introduce an unconditional `Deno.env.get()` in library initialization or normal signal creation. Logging tests should stub permission and environment APIs rather than granting environment permission to the entire test suite.
+
+## Testing conventions
+
+- Register every case as an independent top-level `Deno.test`. Do not use test steps or `@std/testing/bdd`.
+- Use `@std/expect` for expectations and `@std/testing/mock` for spies and stubs.
+- Name tests `<function-or-method>() <behavior>`, such as `signal() should create a writable signal` or `WritableSignal.set() should update the value`. Always include parentheses after the callable name.
+- Declare tests with `Deno.test(name, fn)`. Use arrow functions for `fn`, including `async` arrow functions for asynchronous tests.
+- Use `using` for disposable stubs and event signals so cleanup happens even when assertions fail.
+- Cover both runtime behavior and public type expectations when changing an API contract.
+- Effects run asynchronously unless the API explicitly promises immediate execution. Await a short delay or a microtask before asserting scheduled work.
+- Tests must be deterministic and isolated: restore global stubs, destroy effects, dispose event listeners, and avoid depending on ambient environment variables.
+
+## Documentation
+
+Update documentation in the same change as user-visible behavior:
+
+- `module/README.md` for installation, overview, and common examples.
+- The matching page under `docs/` for detailed behavior.
+- Source JSDoc for API-level contracts and generated reference documentation.
+
+Docs pages use YAML front matter with `title`, `description`, and a `/reactivity/...` URL. Use `@deft-plus/reactivity` in consumer examples, keep method and option names identical to the source, and ensure examples reflect asynchronous effect timing and signal return shapes.
+
+## Package and release rules
+
+- Keep package metadata, imports, and exports in `module/deno.jsonc`.
+- Commit `deno.lock` and keep it synchronized. CI uses `deno ci` and must fail on a stale lockfile.
+- Publishing targets JSR through `deno publish`; the release workflow uses OIDC provenance.
+- Do not edit generated `.coverage/` or `.deno-docs/` output.
+- Avoid adding production dependencies for functionality the Deno runtime already provides.

--- a/cspell.json
+++ b/cspell.json
@@ -2,5 +2,5 @@
   "version": "0.2",
   "allowCompoundWords": true,
   "ignorePaths": [".vscode", ".github/workflows"],
-  "words": ["deno"]
+  "words": ["deno", "denoland"]
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -2,13 +2,13 @@
   "tasks": {
     "lint": "deno lint && deno fmt --check",
     "fmt": "deno fmt",
-    "test": "rm -rf .coverage && deno test -A --coverage=.coverage **/*_test.ts ; deno coverage .coverage",
-    "test:u": "rm -rf .coverage && deno test -A --coverage=.coverage **/*_test.ts -- -u ; deno coverage .coverage",
+    "check": "deno check module/mod.ts module/**/*_test.ts",
+    "test": "deno test --coverage=.coverage --clean module && deno coverage --threshold=100 .coverage",
+    "test:u": "deno test --coverage=.coverage --clean module -- -u && deno coverage --threshold=100 .coverage",
     "jsdoc:generate": "rm -rf .deno-docs && deno doc --html --output=./.deno-docs module/**/*.ts",
     "jsdoc:lint": "deno doc --lint module/*.ts"
   },
   "workspace": ["./module", "./docs"],
-  "lock": false,
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "dom.extras", "deno.ns"],
     "strict": true,
@@ -23,7 +23,7 @@
   },
   "fmt": {
     "include": ["./"],
-    "exclude": [".git", ".coverage", ".deno-docs"],
+    "exclude": [".git", ".agents", ".coverage", ".deno-docs"],
     "useTabs": false,
     "lineWidth": 100,
     "indentWidth": 2,
@@ -31,7 +31,7 @@
     "proseWrap": "never"
   },
   "lint": {
-    "exclude": [".git", ".coverage", ".deno-docs"],
+    "exclude": [".git", ".agents", ".coverage", ".deno-docs"],
     "rules": {
       "tags": ["recommended"],
       "include": [

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,78 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@^1.5.0": "1.5.0",
+    "jsr:@std/data-structures@^1.1.1": "1.1.2",
+    "jsr:@std/data-structures@^1.1.2": "1.1.2",
+    "jsr:@std/expect@^1.0.20": "1.0.20",
+    "jsr:@std/fs@^1.0.24": "1.0.24",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@^1.1.5": "1.1.6",
+    "jsr:@std/path@^1.1.6": "1.1.6",
+    "jsr:@std/testing@^1.0.20": "1.0.20"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/async@1.5.0": {
+      "integrity": "4c1f22d287a17ad7d8643b1952bc5a4d21e5d8b68dc8c20d8268eecc69096e82",
+      "dependencies": [
+        "jsr:@std/data-structures@^1.1.1"
+      ]
+    },
+    "@std/data-structures@1.1.2": {
+      "integrity": "2471377c9e0051f9ec34e57d0ebd0ad133a5a889677446ec6ba9938e4e102918"
+    },
+    "@std/expect@1.0.20": {
+      "integrity": "ffc4f3c33f732417e3e9acf3d995818c89984313c37d933b9ebbb4571d2887e9",
+      "dependencies": [
+        "jsr:@std/assert",
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.6"
+      ]
+    },
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
+      "dependencies": [
+        "jsr:@std/path@^1.1.5"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
+    },
+    "@std/testing@1.0.20": {
+      "integrity": "21380ed438672762e4ec549cbf4fe41c5b68f5598773a30b64abe7375513e721",
+      "dependencies": [
+        "jsr:@std/assert",
+        "jsr:@std/async",
+        "jsr:@std/data-structures@^1.1.2",
+        "jsr:@std/fs",
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.6"
+      ]
+    }
+  },
+  "workspace": {
+    "members": {
+      "module": {
+        "dependencies": [
+          "jsr:@std/async@^1.5.0",
+          "jsr:@std/expect@^1.0.20",
+          "jsr:@std/testing@^1.0.20"
+        ]
+      }
+    }
+  }
+}

--- a/module/README.md
+++ b/module/README.md
@@ -18,6 +18,16 @@ Or using npm:
 npx jsr add @deft-plus/reactivity
 ```
 
+### Global logging
+
+Set `SIGNAL_LOG=true` to enable logging for every signal when the application grants access to that environment variable:
+
+```bash
+SIGNAL_LOG=true deno run --allow-env=SIGNAL_LOG app.ts
+```
+
+Without environment permission, global logging safely remains disabled. A signal-level `log` option always takes precedence, so `{ log: false }` can disable logging for an individual signal.
+
 ## Signals
 
 Signals provide a way to create reactive values that automatically notify consumers when their value changes. They allow for fine-grained reactivity and lazy evaluation, making them ideal for performance-sensitive applications.

--- a/module/_api.ts
+++ b/module/_api.ts
@@ -69,7 +69,7 @@ export function getSignalType<T>(signal: Signal<T>): SignalType {
  * @returns `true` if the value is a signal ({@link Signal}), `false` otherwise.
  */
 export function isSignal<T = unknown>(value: unknown): value is Signal<T> {
-  return value !== null && SIGNAL_TYPES.includes((value as ReadonlySignal<T>)[SIGNAL]);
+  return typeof value === 'function' && SIGNAL_TYPES.includes((value as ReadonlySignal<T>)[SIGNAL]);
 }
 
 /**

--- a/module/_api_test.ts
+++ b/module/_api_test.ts
@@ -1,60 +1,61 @@
 // Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
 
-import { describe as group, test } from '@std/testing/bdd';
 import { expect } from '@std/expect';
 
 import { defaultEquals, isSignal, markAsSignal } from './_api.ts';
 import { signal } from './signal.ts';
 import { memoSignal } from './memo.ts';
 
-group('reactive / api', () => {
-  group('defaultEquals()', () => {
-    test('should compare two values', () => {
-      expect(defaultEquals(1, 1)).toBe(true);
-      expect(defaultEquals(1, 2)).toBe(false);
-    });
+Deno.test('defaultEquals() should compare two values', () => {
+  expect(defaultEquals(1, 1)).toBe(true);
+  expect(defaultEquals(1, 2)).toBe(false);
+});
 
-    test('should compare two objects', () => {
-      const obj1 = { name: 'Alice', age: 42 };
-      const obj2 = { name: 'Alice', age: 42 };
+Deno.test('defaultEquals() should treat objects as unequal by default', () => {
+  const obj1 = { name: 'Alice', age: 42 };
+  const obj2 = { name: 'Alice', age: 42 };
 
-      expect(defaultEquals(obj1, obj2)).toBe(false);
-    });
-  });
+  expect(defaultEquals(obj1, obj2)).toBe(false);
+});
 
-  group('isSignal()', () => {
-    test('should check if a value is a signal', () => {
-      const notSignal = 42;
-      const validSignal = signal(42);
+Deno.test('isSignal() should identify signal values', () => {
+  const notSignal = 42;
+  const validSignal = signal(42);
 
-      expect(isSignal(notSignal)).toBe(false);
-      expect(isSignal(validSignal)).toBe(true);
-    });
+  expect(isSignal(notSignal)).toBe(false);
+  expect(isSignal(validSignal)).toBe(true);
+});
 
-    test('should check very specific signal types', () => {
-      const notSignal = 42;
-      const validSignal = signal(42);
-      const validReadonly = validSignal.readonly();
-      const validMemo = memoSignal(() => validSignal());
+Deno.test('isSignal() should return false for nullish values', () => {
+  expect(isSignal(undefined)).toBe(false);
+  expect(isSignal(null)).toBe(false);
+  expect(isSignal.writable(undefined)).toBe(false);
+  expect(isSignal.readonly(undefined)).toBe(false);
+  expect(isSignal.memoized(undefined)).toBe(false);
+});
 
-      expect(isSignal(notSignal)).toBe(false);
-      expect(isSignal(validSignal)).toBe(true);
+Deno.test('isSignal() type guards should identify specific signal types', () => {
+  const notSignal = 42;
+  const validSignal = signal(42);
+  const validReadonly = validSignal.readonly();
+  const validMemo = memoSignal(() => validSignal());
 
-      expect(isSignal.writable(validSignal)).toBe(true);
-      expect(isSignal.writable(validReadonly)).toBe(false);
+  expect(isSignal(notSignal)).toBe(false);
+  expect(isSignal(validSignal)).toBe(true);
 
-      expect(isSignal.readonly(validReadonly)).toBe(true);
-      expect(isSignal.readonly(validMemo)).toBe(false);
+  expect(isSignal.writable(validSignal)).toBe(true);
+  expect(isSignal.writable(validReadonly)).toBe(false);
 
-      expect(isSignal.memoized(validMemo)).toBe(true);
-      expect(isSignal.memoized(validSignal)).toBe(false);
-    });
-  });
+  expect(isSignal.readonly(validReadonly)).toBe(true);
+  expect(isSignal.readonly(validMemo)).toBe(false);
 
-  test('markAsSignal() - should mark a functions as a signal', () => {
-    const value = () => 42;
-    const signalValue = markAsSignal('writable', value);
+  expect(isSignal.memoized(validMemo)).toBe(true);
+  expect(isSignal.memoized(validSignal)).toBe(false);
+});
 
-    expect(isSignal(signalValue)).toBe(true);
-  });
+Deno.test('markAsSignal() should mark a function as a signal', () => {
+  const value = () => 42;
+  const signalValue = markAsSignal('writable', value);
+
+  expect(isSignal(signalValue)).toBe(true);
 });

--- a/module/_logging.ts
+++ b/module/_logging.ts
@@ -1,0 +1,33 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+/**
+ * Contains the logging resolver for the configuration.
+ *
+ * @module
+ */
+
+/** Name of the environment variable that enables signal logging globally. */
+const SIGNAL_LOG_ENV = 'SIGNAL_LOG';
+
+/**
+ * Resolves whether logging is enabled for a signal.
+ *
+ * An explicit option takes precedence. Otherwise, the global environment setting is used only when
+ * the runtime grants access to it. Runtimes without the Deno API and denied permissions safely
+ * default to disabled logging.
+ */
+export function resolveSignalLog(log?: boolean): boolean {
+  if (log !== undefined) {
+    return log;
+  }
+
+  // deno-coverage-ignore-start -- Deno's test runner cannot execute without the Deno global.
+  if (typeof Deno === 'undefined') {
+    return false;
+  }
+  // deno-coverage-ignore-stop
+
+  const permission = Deno.permissions.querySync({ name: 'env', variable: SIGNAL_LOG_ENV });
+
+  return permission.state === 'granted' && Deno.env.get(SIGNAL_LOG_ENV) === 'true';
+}

--- a/module/_logging_test.ts
+++ b/module/_logging_test.ts
@@ -1,0 +1,83 @@
+// Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
+
+import { assertSpyCalls, stub } from '@std/testing/mock';
+import { expect } from '@std/expect';
+
+import { resolveSignalLog } from './_logging.ts';
+import { memoSignal } from './memo.ts';
+import { signal } from './signal.ts';
+import { store } from './store.ts';
+
+const permissionStatus = (state: Deno.PermissionState): Deno.PermissionStatus =>
+  ({ state, partial: false, onchange: null }) as Deno.PermissionStatus;
+
+Deno.test('resolveSignalLog() should prioritize an explicit logging option', () => {
+  using permissionStub = stub(
+    Deno.permissions,
+    'querySync',
+    () => permissionStatus('granted'),
+  );
+
+  expect(resolveSignalLog(true)).toBe(true);
+  expect(resolveSignalLog(false)).toBe(false);
+  assertSpyCalls(permissionStub, 0);
+});
+
+Deno.test('resolveSignalLog() should disable global logging when environment access is denied', () => {
+  using permissionStub = stub(
+    Deno.permissions,
+    'querySync',
+    () => permissionStatus('denied'),
+  );
+  using envStub = stub(Deno.env, 'get', () => 'true');
+
+  expect(resolveSignalLog()).toBe(false);
+  assertSpyCalls(permissionStub, 1);
+  assertSpyCalls(envStub, 0);
+});
+
+Deno.test('resolveSignalLog() should enable global logging when the environment setting is accessible', () => {
+  using permissionStub = stub(
+    Deno.permissions,
+    'querySync',
+    () => permissionStatus('granted'),
+  );
+  using envStub = stub(Deno.env, 'get', () => 'true');
+  using consoleStub = stub(console, 'log', () => {});
+
+  const counter = signal(0);
+  const doubleCounter = memoSignal(() => counter() * 2);
+
+  counter.set(1);
+  expect(doubleCounter()).toBe(2);
+
+  assertSpyCalls(permissionStub, 2);
+  assertSpyCalls(envStub, 2);
+  assertSpyCalls(consoleStub, 6);
+});
+
+Deno.test('resolveSignalLog() should let local options disable global logging', () => {
+  using permissionStub = stub(
+    Deno.permissions,
+    'querySync',
+    () => permissionStatus('granted'),
+  );
+  using envStub = stub(Deno.env, 'get', () => 'true');
+  using consoleStub = stub(console, 'log', () => {});
+
+  const counter = signal(0, { log: false });
+  const doubleCounter = memoSignal(() => counter() * 2, { log: false });
+  const counterStore = store<{ count: number; increment: () => void }>(({ get }) => ({
+    count: { value: 0, log: false },
+    increment: () => get().count.update((value) => value + 1),
+  }));
+
+  counter.set(1);
+  expect(doubleCounter()).toBe(2);
+  counterStore().increment();
+  expect(counterStore().count()).toBe(1);
+
+  assertSpyCalls(permissionStub, 0);
+  assertSpyCalls(envStub, 0);
+  assertSpyCalls(consoleStub, 0);
+});

--- a/module/_reactive_node.ts
+++ b/module/_reactive_node.ts
@@ -178,9 +178,13 @@ interface Dependency {
 }
 
 /** Configuration for logging changes in the reactive node. */
-interface LogConfig {
+export interface LogConfig {
+  /** Reactive value type displayed in the log heading. */
   type: string;
+  /** Human-readable name of the reactive value. */
   name: string;
+  /** Value after the reactive update. */
   newValue: unknown;
+  /** Value before the reactive update. */
   oldValue: unknown;
 }

--- a/module/_reactive_node.ts
+++ b/module/_reactive_node.ts
@@ -57,10 +57,10 @@ export abstract class ReactiveNode {
   }
 
   /** Called when a dependency may have changed. */
-  protected abstract onDependencyChange(): void;
+  protected onDependencyChange(): void {}
 
   /** Called when a consumer checks if the producer's value has changed. */
-  protected abstract onProducerMayChanged(): void;
+  protected onProducerMayChanged(): void {}
 
   /**
    * Checks if any of this node's dependencies have actually changed.

--- a/module/_reactive_node_test.ts
+++ b/module/_reactive_node_test.ts
@@ -1,10 +1,103 @@
 // Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
 
-import { describe as group, test } from '@std/testing/bdd';
 import { expect } from '@std/expect';
+import { ReactiveNode } from './_reactive_node.ts';
 
-group('reactive / ReactiveNode()', () => {
-  test('should pass', () => {
-    expect(true).toBe(true);
-  });
+class TestReactiveNode extends ReactiveNode {
+  public dependencyChanges = 0;
+
+  public get hasDependencies(): boolean {
+    return this.hasProducers;
+  }
+
+  public read(): void {
+    this.recordAccess();
+  }
+
+  public write(): void {
+    this.valueVersion++;
+    this.notifyConsumers();
+  }
+
+  public track(read: () => void): void {
+    const previousConsumer = ReactiveNode.setActiveConsumer(this);
+    this.trackingVersion++;
+    try {
+      read();
+    } finally {
+      ReactiveNode.setActiveConsumer(previousConsumer);
+    }
+  }
+
+  public dependenciesChanged(): boolean {
+    return this.haveDependenciesChanged();
+  }
+
+  public checkForProducerChanges(): void {
+    this.onProducerMayChanged();
+  }
+
+  protected override onDependencyChange(): void {
+    this.dependencyChanges++;
+  }
+}
+
+class ReadingConsumerNode extends TestReactiveNode {
+  public constructor(private producer: TestReactiveNode) {
+    super();
+  }
+
+  protected override onDependencyChange(): void {
+    this.producer.read();
+  }
+}
+
+class DefaultReactiveNode extends ReactiveNode {
+  public notifyDependencyChange(): void {
+    this.onDependencyChange();
+  }
+}
+
+Deno.test('ReactiveNode() should report tracked dependencies', () => {
+  const producer = new TestReactiveNode();
+  const consumer = new TestReactiveNode();
+
+  expect(consumer.hasDependencies).toBe(false);
+  consumer.track(() => producer.read());
+  expect(consumer.hasDependencies).toBe(true);
+});
+
+Deno.test('ReactiveNode.haveDependenciesChanged() should remove stale dependencies', () => {
+  const staleProducer = new TestReactiveNode();
+  const activeProducer = new TestReactiveNode();
+  const consumer = new TestReactiveNode();
+
+  consumer.track(() => staleProducer.read());
+  consumer.track(() => activeProducer.read());
+
+  expect(consumer.dependenciesChanged()).toBe(false);
+
+  staleProducer.write();
+  expect(consumer.dependencyChanges).toBe(0);
+  expect(consumer.hasDependencies).toBe(true);
+});
+
+Deno.test('ReactiveNode.recordAccess() should reject reads during notification', () => {
+  const producer = new TestReactiveNode();
+  const consumer = new ReadingConsumerNode(producer);
+  consumer.track(() => producer.read());
+
+  expect(() => producer.write()).toThrow('Cannot read signals during notification phase.');
+});
+
+Deno.test('ReactiveNode.onProducerMayChanged() should default to a no-op', () => {
+  const node = new TestReactiveNode();
+
+  expect(() => node.checkForProducerChanges()).not.toThrow();
+});
+
+Deno.test('ReactiveNode.onDependencyChange() should default to a no-op', () => {
+  const node = new DefaultReactiveNode();
+
+  expect(() => node.notifyDependencyChange()).not.toThrow();
 });

--- a/module/deno.jsonc
+++ b/module/deno.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://jsr.io/schema/config-file.v1.json",
   "name": "@deft-plus/reactivity",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "🎯 Seamlessly manage reactive state with signals, enabling automatic updates and fine-grained reactivity across your application.",
   "keywords": [
     "deno",

--- a/module/deno.jsonc
+++ b/module/deno.jsonc
@@ -3,7 +3,16 @@
   "name": "@deft-plus/reactivity",
   "version": "0.1.0",
   "description": "🎯 Seamlessly manage reactive state with signals, enabling automatic updates and fine-grained reactivity across your application.",
-  "keywords": ["deno", "signal", "store", "reactive", "reactivity", "atomic", "state", "global"],
+  "keywords": [
+    "deno",
+    "signal",
+    "store",
+    "reactive",
+    "reactivity",
+    "atomic",
+    "state",
+    "global"
+  ],
   "license": "Apache-2.0",
   "author": "Deft+",
   "homepage": "https://github.com/deft-plus/reactivity#README.md",
@@ -12,9 +21,9 @@
     "url": "git+https://github.com/deft-plus/reactivity.git"
   },
   "imports": {
-    "@std/async": "jsr:@std/async@^1.0.6",
-    "@std/expect": "jsr:@std/expect@^1.0.5",
-    "@std/testing": "jsr:@std/testing@^1.0.3"
+    "@std/async": "jsr:@std/async@^1.5.0",
+    "@std/expect": "jsr:@std/expect@^1.0.20",
+    "@std/testing": "jsr:@std/testing@^1.0.20"
   },
   "exports": {
     ".": "./mod.ts"

--- a/module/effect.ts
+++ b/module/effect.ts
@@ -97,8 +97,8 @@ export function effect(callback: EffectCallback): EffectRef {
  * @returns A reference ({@link EffectRef}) to the effect that can be manually destroyed.
  */
 effect.initial = function (callback: EffectCallback): EffectRef {
-  callback();
-  return effect(callback);
+  const watch = new EffectImpl(callback);
+  return watch.effect(true);
 };
 
 /** Stop all active effects. */
@@ -141,26 +141,31 @@ class EffectImpl extends ReactiveNode {
     this.notify();
   }
 
-  /** Called when a consumer checks if the producer's value has changed. */
-  protected override onProducerMayChanged(): void {
-    // Watches don't update producer values.
-  }
-
   /**
    * Get the effect reference.
    *
    * @returns A reference to the effect ({@link EffectRef}).
    */
-  public effect(): EffectRef {
+  public effect(initial = false): EffectRef {
     EffectImpl.activeEffects.add(this);
 
-    // Schedule the effect to run.
-    this.notify();
+    if (initial) {
+      this.run();
+    } else {
+      // Schedule the effect to run.
+      this.notify();
+    }
 
+    let destroyed = false;
     const destroy = () => {
-      this.cleanup();
+      if (destroyed) {
+        return;
+      }
+
+      destroyed = true;
       EffectImpl.activeEffects.delete(this);
       EffectImpl.executionQueue.delete(this);
+      this.cleanup();
     };
 
     return {
@@ -204,7 +209,9 @@ class EffectImpl extends ReactiveNode {
 
   /** Run the cleanup function. */
   private cleanup(): void {
-    this.cleanupFn();
+    const cleanupFn = this.cleanupFn;
+    this.cleanupFn = NOOP_CLEANUP;
+    cleanupFn();
   }
 
   /** Queue an effect for execution. */

--- a/module/effect.ts
+++ b/module/effect.ts
@@ -130,10 +130,14 @@ class EffectImpl extends ReactiveNode {
   /** Property to track the current tracking version. */
   private cleanupFn = NOOP_CLEANUP;
 
+  /** Whether this effect has already been destroyed. */
+  private destroyed = false;
+
   /** Stop all active effects. */
   public static resetEffects(): void {
-    EffectImpl.executionQueue.clear();
-    EffectImpl.activeEffects.clear();
+    for (const effect of EffectImpl.activeEffects) {
+      effect.destroy();
+    }
   }
 
   /** Called when a dependency may have changed. */
@@ -156,24 +160,24 @@ class EffectImpl extends ReactiveNode {
       this.notify();
     }
 
-    let destroyed = false;
-    const destroy = () => {
-      if (destroyed) {
-        return;
-      }
-
-      destroyed = true;
-      EffectImpl.activeEffects.delete(this);
-      EffectImpl.executionQueue.delete(this);
-      this.cleanup();
-    };
-
     return {
-      destroy,
+      destroy: () => this.destroy(),
       [Symbol.dispose]: () => {
-        destroy();
+        this.destroy();
       },
     };
+  }
+
+  /** Destroy this effect and run its cleanup function once. */
+  private destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+    EffectImpl.activeEffects.delete(this);
+    EffectImpl.executionQueue.delete(this);
+    this.cleanup();
   }
 
   /** Notify that this watch needs to be re-scheduled. */

--- a/module/effect_test.ts
+++ b/module/effect_test.ts
@@ -126,9 +126,11 @@ Deno.test('effect() should skip execution when dependency values do not change',
 Deno.test('effect.resetEffects() should stop all active effects', async () => {
   const value = signal(0);
   const changes: number[] = [];
+  let cleanupCalls = 0;
 
-  effect(() => {
+  const effectRef = effect(() => {
     changes.push(value());
+    return () => cleanupCalls++;
   });
 
   expect(changes).toEqual([]);
@@ -138,6 +140,10 @@ Deno.test('effect.resetEffects() should stop all active effects', async () => {
   expect(changes).toEqual([1]);
 
   effect.resetEffects();
+  expect(cleanupCalls).toBe(1);
+
+  effectRef.destroy();
+  expect(cleanupCalls).toBe(1);
 
   value.set(2);
   await delay(1);

--- a/module/effect_test.ts
+++ b/module/effect_test.ts
@@ -1,19 +1,72 @@
 // Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
 
-import { describe as group, test } from '@std/testing/bdd';
 import { expect } from '@std/expect';
 
 import { delay } from '@std/async';
 
 import { effect } from './effect.ts';
+import { memoSignal } from './memo.ts';
 import { signal } from './signal.ts';
 
-group('reactive / effect()', () => {
-  test('should listen for signal changes and trigger effects', async () => {
-    const value = signal(0);
-    const changes: number[] = [];
+Deno.test('effect() should listen for signal changes and trigger effects', async () => {
+  const value = signal(0);
+  const changes: number[] = [];
 
-    const effectRef = effect(() => {
+  const effectRef = effect(() => {
+    changes.push(value());
+  });
+
+  expect(changes).toEqual([]);
+
+  value.set(1);
+  await delay(1);
+  expect(changes).toEqual([1]);
+
+  value.set(2);
+  await delay(1);
+  expect(changes).toEqual([1, 2]);
+
+  effectRef.destroy();
+});
+
+Deno.test('EffectRef.destroy() should stop the effect', async () => {
+  const value = signal(0);
+  const changes: number[] = [];
+
+  const effectRef = effect(() => {
+    changes.push(value());
+  });
+
+  expect(changes).toEqual([]);
+
+  value.set(1);
+  await delay(1);
+  expect(changes).toEqual([1]);
+
+  effectRef.destroy();
+
+  value.set(2);
+  await delay(1);
+  expect(changes).toEqual([1]);
+});
+
+Deno.test('EffectRef.destroy() should be idempotent', () => {
+  let cleanupCalls = 0;
+  const effectRef = effect.initial(() => () => cleanupCalls++);
+
+  effectRef.destroy();
+  effectRef.destroy();
+  effectRef[Symbol.dispose]();
+
+  expect(cleanupCalls).toBe(1);
+});
+
+Deno.test('EffectRef[Symbol.dispose]() should stop the effect when it leaves scope', async () => {
+  const value = signal(0);
+  const changes: number[] = [];
+
+  {
+    using _effectRef = effect(() => {
       changes.push(value());
     });
 
@@ -22,95 +75,71 @@ group('reactive / effect()', () => {
     value.set(1);
     await delay(1);
     expect(changes).toEqual([1]);
+  }
 
-    value.set(2);
-    await delay(1);
-    expect(changes).toEqual([1, 2]);
+  value.set(2);
+  await delay(1);
+  expect(changes).toEqual([1]);
+});
 
-    effectRef.destroy();
+Deno.test('effect.initial() should run the effect immediately', async () => {
+  const value = signal(0);
+  const changes = [] as number[];
+
+  const effectRef = effect.initial(() => {
+    changes.push(value());
   });
 
-  test('should stop an effect when destroyed', async () => {
-    const value = signal(0);
-    const changes: number[] = [];
+  expect(changes).toEqual([0]);
+  await delay(1);
+  expect(changes).toEqual([0]);
 
-    const effectRef = effect(() => {
-      changes.push(value());
-    });
+  value.set(1);
+  await delay(1);
+  expect(changes).toEqual([0, 1]);
 
-    expect(changes).toEqual([]);
+  value.set(2);
+  await delay(1);
+  expect(changes).toEqual([0, 1, 2]);
 
-    value.set(1);
-    await delay(1);
-    expect(changes).toEqual([1]);
+  effectRef.destroy();
+});
 
-    effectRef.destroy();
-
-    value.set(2);
-    await delay(1);
-    expect(changes).toEqual([1]);
+Deno.test('effect() should skip execution when dependency values do not change', async () => {
+  const source = signal(1);
+  const parity = memoSignal(() => source() % 2);
+  const changes: number[] = [];
+  const effectRef = effect(() => {
+    changes.push(parity());
   });
 
-  test('should stop an effect when out of scope', async () => {
-    const value = signal(0);
-    const changes: number[] = [];
+  await delay(1);
+  expect(changes).toEqual([1]);
 
-    {
-      using _effectRef = effect(() => {
-        changes.push(value());
-      });
+  source.set(3);
+  await delay(1);
+  expect(changes).toEqual([1]);
 
-      expect(changes).toEqual([]);
+  effectRef.destroy();
+});
 
-      value.set(1);
-      await delay(1);
-      expect(changes).toEqual([1]);
-    }
+Deno.test('effect.resetEffects() should stop all active effects', async () => {
+  const value = signal(0);
+  const changes: number[] = [];
 
-    value.set(2);
-    await delay(1);
-    expect(changes).toEqual([1]);
+  effect(() => {
+    changes.push(value());
   });
 
-  test('should allow to use the `initial` method to run the effect immediately', async () => {
-    const value = signal(0);
-    const changes = [] as number[];
+  expect(changes).toEqual([]);
 
-    const effectRef = effect.initial(() => {
-      changes.push(value());
-    });
+  value.set(1);
+  await delay(1);
+  expect(changes).toEqual([1]);
 
-    expect(changes).toEqual([0]);
+  effect.resetEffects();
 
-    value.set(1);
-    await delay(1);
-    expect(changes).toEqual([0, 1]);
-
-    value.set(2);
-    await delay(1);
-    expect(changes).toEqual([0, 1, 2]);
-
-    effectRef.destroy();
-  });
-
-  test('should reset all active effects', async () => {
-    const value = signal(0);
-    const changes: number[] = [];
-
-    effect(() => {
-      changes.push(value());
-    });
-
-    expect(changes).toEqual([]);
-
-    value.set(1);
-    await delay(1);
-    expect(changes).toEqual([1]);
-
-    effect.resetEffects();
-
-    value.set(2);
-    await delay(1);
-    expect(changes).toEqual([1]);
-  });
+  value.set(2);
+  await delay(1);
+  expect(changes).toEqual([1]);
 });

--- a/module/memo.ts
+++ b/module/memo.ts
@@ -28,6 +28,7 @@ import {
   type MemoizedSignal,
   type MemoizedSignalOptions,
 } from './_api.ts';
+import { resolveSignalLog } from './_logging.ts';
 import { ReactiveNode } from './_reactive_node.ts';
 import { untrackedSignal } from './untracked.ts';
 
@@ -76,7 +77,7 @@ export function memoSignal<T>(
 ): MemoizedSignal<T> {
   const {
     name = `memo_signal_${Math.random().toString(36).slice(2)}`,
-    log = Deno.env.get('SIGNAL_LOG') === 'true',
+    log = resolveSignalLog(options?.log),
     equal = defaultEquals,
     subscribe = () => {},
   } = options ?? {};
@@ -84,6 +85,7 @@ export function memoSignal<T>(
   const node = new MemoizedSignalImp(compute, { name, log, equal, subscribe });
 
   return markAsSignal('memoized', node.signal.bind(node), {
+    identifier: name,
     untracked: node.untracked.bind(node),
     toString: node.toString.bind(node),
   });

--- a/module/memo_test.ts
+++ b/module/memo_test.ts
@@ -1,6 +1,5 @@
 // Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
 
-import { describe as group, test } from '@std/testing/bdd';
 import { assertSpyCalls, stub } from '@std/testing/mock';
 import { expect } from '@std/expect';
 
@@ -11,244 +10,248 @@ import { memoSignal } from './memo.ts';
 import { signal } from './signal.ts';
 import { effect } from './effect.ts';
 
-group('reactive / memoSignal()', () => {
-  test('should allow to create a memoized signal', () => {
-    const counter = signal(0);
-    const doubleCounter = memoSignal(() => counter() * 2);
+Deno.test('memoSignal() should create a memoized signal', () => {
+  const counter = signal(0);
+  const doubleCounter = memoSignal(() => counter() * 2);
 
-    expect(doubleCounter()).toBe(0);
+  expect(doubleCounter()).toBe(0);
 
-    counter.set(1);
+  counter.set(1);
 
-    expect(doubleCounter()).toBe(2);
+  expect(doubleCounter()).toBe(2);
+});
+
+Deno.test('memoSignal() should expose its configured name as the identifier', () => {
+  const value = memoSignal(() => 42, { name: 'answer' });
+
+  expect(value.identifier).toBe('answer');
+});
+
+Deno.test('memoSignal() should support a custom equality function', () => {
+  const counter = signal(0);
+
+  // Can only be set to a value greater than or equal to the current value.
+  const doubleCounter = memoSignal(
+    () => counter() * 2,
+    { equal: (a, b) => a >= b },
+  );
+
+  expect(doubleCounter()).toBe(0);
+
+  counter.set(1);
+
+  expect(doubleCounter()).toBe(2);
+
+  counter.set(4);
+
+  expect(doubleCounter()).toBe(8);
+
+  counter.set(2);
+
+  expect(doubleCounter()).toBe(8);
+
+  counter.set(1);
+
+  expect(doubleCounter()).toBe(8);
+});
+
+Deno.test('memoSignal() should schedule on dependencies (memoized) change', async () => {
+  const counter = signal(0);
+  const doubleCounter = memoSignal(() => counter() * 2);
+
+  const effectCounter = [] as number[];
+
+  effect(() => {
+    effectCounter.push(doubleCounter());
   });
 
-  test('should allow to use memoized values with different equals fn', () => {
-    const counter = signal(0);
+  await delay(1);
+  expect(effectCounter).toStrictEqual([0]);
 
-    // Can only be set to a value greater than or equal to the current value.
-    const doubleCounter = memoSignal(
-      () => counter() * 2,
-      { equal: (a, b) => a >= b },
-    );
+  counter.set(1);
 
-    expect(doubleCounter()).toBe(0);
+  await delay(1);
+  expect(effectCounter).toStrictEqual([0, 2]);
+});
 
-    counter.set(1);
+Deno.test('memoSignal() should apply its configuration options', () => {
+  using consoleStub = stub(console, 'log', (_) => {});
 
-    expect(doubleCounter()).toBe(2);
+  const newCalled = [] as number[];
+  const oldCalled = [] as number[];
+  const counter = signal(0);
 
-    counter.set(4);
-
-    expect(doubleCounter()).toBe(8);
-
-    counter.set(2);
-
-    expect(doubleCounter()).toBe(8);
-
-    counter.set(1);
-
-    expect(doubleCounter()).toBe(8);
-  });
-
-  test('should schedule on dependencies (memoized) change', async () => {
-    const counter = signal(0);
-    const doubleCounter = memoSignal(() => counter() * 2);
-
-    const effectCounter = [] as number[];
-
-    effect(() => {
-      effectCounter.push(doubleCounter());
-    });
-
-    await delay(1);
-    expect(effectCounter).toStrictEqual([0]);
-
-    counter.set(1);
-
-    await delay(1);
-    expect(effectCounter).toStrictEqual([0, 2]);
-  });
-
-  test('should allow to pass a config object', () => {
-    using consoleStub = stub(console, 'log', (_) => {});
-
-    const newCalled = [] as number[];
-    const oldCalled = [] as number[];
-    const counter = signal(0);
-
-    const doubleCounter = memoSignal(
-      () => counter() * 2,
-      {
-        name: 'doubleCounter',
-        log: true,
-        subscribe: (newValue, oldValue) => {
-          newCalled.push(newValue);
-          oldCalled.push(oldValue);
-        },
+  const doubleCounter = memoSignal(
+    () => counter() * 2,
+    {
+      name: 'doubleCounter',
+      log: true,
+      subscribe: (newValue, oldValue) => {
+        newCalled.push(newValue);
+        oldCalled.push(oldValue);
       },
-    );
+    },
+  );
 
-    expect(doubleCounter()).toBe(0);
+  expect(doubleCounter()).toBe(0);
 
-    expect(newCalled).toStrictEqual([0]);
-    expect(oldCalled).toStrictEqual([undefined]);
+  expect(newCalled).toStrictEqual([0]);
+  expect(oldCalled).toStrictEqual([undefined]);
 
-    counter.set(1);
-    expect(doubleCounter()).toBe(2);
-    expect(newCalled).toStrictEqual([0, 2]);
-    expect(oldCalled).toStrictEqual([undefined, 0]);
+  counter.set(1);
+  expect(doubleCounter()).toBe(2);
+  expect(newCalled).toStrictEqual([0, 2]);
+  expect(oldCalled).toStrictEqual([undefined, 0]);
 
-    counter.set(23);
-    expect(doubleCounter()).toBe(46);
-    expect(newCalled).toStrictEqual([0, 2, 46]);
-    expect(oldCalled).toStrictEqual([undefined, 0, 2]);
+  counter.set(23);
+  expect(doubleCounter()).toBe(46);
+  expect(newCalled).toStrictEqual([0, 2, 46]);
+  expect(oldCalled).toStrictEqual([undefined, 0, 2]);
 
-    counter.set(23);
-    expect(doubleCounter()).toBe(46);
-    expect(newCalled).toStrictEqual([0, 2, 46]);
-    expect(oldCalled).toStrictEqual([undefined, 0, 2]);
+  counter.set(23);
+  expect(doubleCounter()).toBe(46);
+  expect(newCalled).toStrictEqual([0, 2, 46]);
+  expect(oldCalled).toStrictEqual([undefined, 0, 2]);
 
-    assertSpyCalls(consoleStub, 9); // 9 calls since each log is called 3 times.
+  assertSpyCalls(consoleStub, 9); // 9 calls since each log is called 3 times.
+});
+
+Deno.test('memoSignal() should be able to keep track of multiple dependencies and batch changes', () => {
+  const counter = signal(0);
+  const counter2 = signal(0);
+
+  const changes = [] as number[];
+
+  const doubleCounter = memoSignal(() => {
+    const value = counter() * 2 + counter2();
+    changes.push(value);
+    return value;
   });
 
-  test('should be able to keep track of multiple dependencies and batch changes', () => {
-    const counter = signal(0);
-    const counter2 = signal(0);
+  expect(doubleCounter()).toBe(0);
 
-    const changes = [] as number[];
+  counter.set(1);
+  counter2.set(2);
 
-    const doubleCounter = memoSignal(() => {
-      const value = counter() * 2 + counter2();
-      changes.push(value);
-      return value;
-    });
+  expect(doubleCounter()).toBe(4);
+  expect(changes).toStrictEqual([0, 4]);
+});
 
-    expect(doubleCounter()).toBe(0);
+Deno.test('memoSignal() should throw on a circular dependency', () => {
+  let circularCounter: MemoizedSignal<number> | null = null;
 
-    counter.set(1);
-    counter2.set(2);
+  const counter = memoSignal(() => (circularCounter?.() ?? 0) * 2);
+  circularCounter = memoSignal(() => counter());
 
-    expect(doubleCounter()).toBe(4);
-    expect(changes).toStrictEqual([0, 4]);
+  expect(() => counter()).toThrow();
+});
+
+Deno.test('MemoizedSignal.untracked() should not track dependencies', () => {
+  const changes: number[] = [];
+
+  const counter = signal(0);
+  const doubleCounter = memoSignal(() => counter() * 2);
+
+  effect(() => {
+    changes.push(doubleCounter.untracked());
   });
 
-  test('should throw if it having a circular dependency', () => {
-    let circularCounter: MemoizedSignal<number> | null = null;
+  counter.set(1);
 
-    const counter = memoSignal(() => (circularCounter?.() ?? 0) * 2);
-    circularCounter = memoSignal(() => counter());
+  expect(changes).toStrictEqual([]);
 
-    expect(() => counter()).toThrow();
+  counter.set(2);
+
+  expect(changes).toStrictEqual([]);
+});
+
+Deno.test('memoSignal() should update conditional dependencies', () => {
+  const counter = signal(0);
+  const counter2 = signal(0);
+  const condition = signal(false);
+
+  const conditionalSignal = memoSignal(() => condition() ? counter() : counter2());
+
+  expect(conditionalSignal()).toBe(0);
+
+  counter.set(23);
+  expect(conditionalSignal()).toBe(0);
+
+  condition.set(true);
+  expect(conditionalSignal()).toBe(23);
+
+  counter2.set(2);
+  expect(conditionalSignal()).toBe(23);
+});
+
+Deno.test('memoSignal() should not propagate equivalent values', () => {
+  const counter = signal(10);
+  const counter2 = signal(10);
+
+  const doubleCounter = memoSignal(() => counter() + counter2());
+
+  expect(doubleCounter()).toBe(20);
+
+  counter.set(7);
+  counter2.set(13);
+
+  expect(doubleCounter()).toBe(20);
+});
+
+Deno.test('memoSignal() should cache exceptions thrown until computed gets dirty again', () => {
+  const counter = signal(0);
+  const errorCounter = memoSignal(() => {
+    if (counter() === 0) {
+      throw new Error('Counter is zero');
+    }
+
+    return counter();
   });
 
-  test('should not track changes in untracked blocks', () => {
-    const changes: number[] = [];
+  expect(() => errorCounter()).toThrow('Counter is zero');
 
-    const counter = signal(0);
-    const doubleCounter = memoSignal(() => counter() * 2);
+  counter.set(1);
 
-    effect(() => {
-      changes.push(doubleCounter.untracked());
-    });
+  expect(errorCounter()).toBe(1);
+});
 
-    counter.set(1);
-
-    expect(changes).toStrictEqual([]);
-
-    counter.set(2);
-
-    expect(changes).toStrictEqual([]);
+Deno.test("memoSignal() should not update consumers when dependencies don't change", () => {
+  const source = signal(0);
+  const isEven = memoSignal(() => source() % 2 === 0);
+  let updateCounter = 0;
+  const updateTracker = memoSignal(() => {
+    isEven();
+    return updateCounter++;
   });
 
-  test('should allow to use a signal as a condition', () => {
-    const counter = signal(0);
-    const counter2 = signal(0);
-    const condition = signal(false);
+  updateTracker();
+  expect(updateCounter).toEqual(1);
 
-    const conditionalSignal = memoSignal(() => condition() ? counter() : counter2());
+  source.set(1);
+  updateTracker();
+  expect(updateCounter).toEqual(2);
 
-    expect(conditionalSignal()).toBe(0);
+  // Setting the counter to another odd value should not trigger `updateTracker` to update.
+  source.set(3);
+  updateTracker();
+  expect(updateCounter).toEqual(2);
 
-    counter.set(23);
-    expect(conditionalSignal()).toBe(0);
+  source.set(4);
+  updateTracker();
+  expect(updateCounter).toEqual(3);
+});
 
-    condition.set(true);
-    expect(conditionalSignal()).toBe(23);
-
-    counter2.set(2);
-    expect(conditionalSignal()).toBe(23);
-  });
-
-  test('should no re-compute if the value is the same', () => {
-    const counter = signal(10);
-    const counter2 = signal(10);
-
-    const doubleCounter = memoSignal(() => counter() + counter2());
-
-    expect(doubleCounter()).toBe(20);
-
-    counter.set(7);
-    counter2.set(13);
-
-    expect(doubleCounter()).toBe(20);
-  });
-
-  test('should cache exceptions thrown until computed gets dirty again', () => {
-    const counter = signal(0);
-    const errorCounter = memoSignal(() => {
-      if (counter() === 0) {
-        throw new Error('Counter is zero');
-      }
-
-      return counter();
-    });
-
-    expect(() => errorCounter()).toThrow('Counter is zero');
-
-    counter.set(1);
-
-    expect(errorCounter()).toBe(1);
-  });
-
-  test("should not update dependencies of computations when dependencies don't change", () => {
-    const source = signal(0);
-    const isEven = memoSignal(() => source() % 2 === 0);
-    let updateCounter = 0;
-    const updateTracker = memoSignal(() => {
-      isEven();
-      return updateCounter++;
-    });
-
-    updateTracker();
-    expect(updateCounter).toEqual(1);
-
-    source.set(1);
-    updateTracker();
-    expect(updateCounter).toEqual(2);
-
-    // Setting the counter to another odd value should not trigger `updateTracker` to update.
-    source.set(3);
-    updateTracker();
-    expect(updateCounter).toEqual(2);
-
-    source.set(4);
-    updateTracker();
-    expect(updateCounter).toEqual(3);
-  });
-
-  test('should allow signal creation within computed', () => {
-    const doubleCounter = memoSignal(() => {
-      const counter = signal(1);
-      return counter() * 2;
-    });
-
-    expect(doubleCounter()).toBe(2);
-  });
-
-  test('should have a toString implementation', () => {
+Deno.test('memoSignal() should support signal creation during computation', () => {
+  const doubleCounter = memoSignal(() => {
     const counter = signal(1);
-    const doubleCounter = memoSignal(() => counter() * 2);
-    expect(doubleCounter + '').toBe('[MemoSignal: 2]');
+    return counter() * 2;
   });
+
+  expect(doubleCounter()).toBe(2);
+});
+
+Deno.test('MemoizedSignal.toString() should return its string representation', () => {
+  const counter = signal(1);
+  const doubleCounter = memoSignal(() => counter() * 2);
+  expect(doubleCounter + '').toBe('[MemoSignal: 2]');
 });

--- a/module/signal.ts
+++ b/module/signal.ts
@@ -75,6 +75,7 @@ import {
   type SignalOptions,
   type WritableSignal,
 } from './_api.ts';
+import { resolveSignalLog } from './_logging.ts';
 import { ReactiveNode } from './_reactive_node.ts';
 import { untrackedSignal } from './untracked.ts';
 
@@ -175,7 +176,7 @@ export function signal<T>(
 ): WritableSignal<T> | WritableEventSignal<T> {
   const {
     name = `signal_${Math.random().toString(36).slice(2)}`,
-    log = Deno.env.get('SIGNAL_LOG') === 'true',
+    log = resolveSignalLog(options?.log),
     equal = defaultEquals,
     subscribe = () => {},
     allowEvents = false as true,
@@ -225,16 +226,6 @@ class WritableSignalImpl<T> extends ReactiveNode {
 
   /** The current value of the signal as read-only. */
   private readonlySignal?: ReadonlySignal<T>;
-
-  /** Called when a dependency may have changed. */
-  protected override onDependencyChange(): void {
-    // Writable signals are not consumers, so this doesn't apply.
-  }
-
-  /** Called when a consumer checks if the producer's value has changed. */
-  protected override onProducerMayChanged(): void {
-    // Value versions are always up-to-date for writable signals.
-  }
 
   /**
    * Set a new value for the signal and notify consumers if changed.

--- a/module/signal_test.ts
+++ b/module/signal_test.ts
@@ -1,6 +1,5 @@
 // Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
 
-import { describe as group, test } from '@std/testing/bdd';
 import { assertSpyCalls, stub } from '@std/testing/mock';
 import { expect } from '@std/expect';
 
@@ -13,207 +12,205 @@ type TestingUser = {
   age: number;
 };
 
-group('reactive / signal()', () => {
-  test('should create a signal with the given initial value', () => {
-    const counter = signal(0);
+Deno.test('signal() should create a writable signal with the initial value', () => {
+  const counter = signal(0);
 
-    expect(counter()).toBe(0);
+  expect(counter()).toBe(0);
+});
+
+Deno.test('signal() should apply its configuration options', () => {
+  const counter = signal(0, { name: 'counter', log: true });
+
+  expect(counter()).toBe(0);
+});
+
+Deno.test('WritableSignal.set() should replace the current value', () => {
+  const counter = signal(0);
+
+  counter.set(1);
+
+  expect(counter()).toBe(1);
+});
+
+Deno.test('WritableSignal.update() should derive a new value from the current value', () => {
+  const counter = signal(0);
+
+  counter.update((value) => value + 1);
+
+  expect(counter()).toBe(1);
+});
+
+Deno.test('WritableSignal.mutate() should mutate the current value in place', () => {
+  const user = signal<TestingUser>({ name: 'Alice', age: 42 });
+
+  user.mutate((value) => {
+    value.name = 'Bob';
   });
 
-  test('should create a signal with the given options', () => {
-    const counter = signal(0, { name: 'counter', log: true });
+  expect(user().name).toBe('Bob');
+});
 
-    expect(counter()).toBe(0);
+Deno.test('WritableSignal.readonly() should create a readonly signal', () => {
+  const value = signal(0).readonly();
+
+  expect(value()).toBe(0);
+
+  const signalFnKeys = Object.keys(value);
+  const writableKeys = signalFnKeys.find((key) =>
+    key === 'set' || key === 'update' || key === 'mutate'
+  );
+
+  expect(writableKeys).toBe(undefined);
+});
+
+Deno.test('WritableSignal.readonly() should stay synchronized with its source', () => {
+  const privateCounter = signal(0);
+
+  const counter = {
+    mutable: privateCounter,
+    readonly: privateCounter.readonly(),
+  };
+
+  expect(counter.readonly()).toBe(0);
+
+  const signalFnKeys = Object.keys(counter.readonly);
+  const writableKeys = signalFnKeys.find((key) =>
+    key === 'set' || key === 'update' || key === 'mutate'
+  );
+
+  expect(writableKeys).toBe(undefined);
+
+  privateCounter.set(1);
+  expect(counter.readonly()).toBe(1);
+
+  counter.mutable.set(2);
+  expect(counter.readonly()).toBe(2);
+});
+
+Deno.test('signal() should call the subscribe hook after value changes', () => {
+  const called = [] as number[];
+
+  const counter = signal(0, {
+    subscribe: (value) => called.push(value),
   });
 
-  test('should allow to set a new value to a signal', () => {
-    const counter = signal(0);
+  expect(called).toStrictEqual([]);
 
-    counter.set(1);
+  counter.set(1);
+  expect(called).toStrictEqual([1]);
 
-    expect(counter()).toBe(1);
+  counter.set(23);
+  expect(called).toStrictEqual([1, 23]);
+
+  counter.set(23);
+  expect(called).toStrictEqual([1, 23]);
+});
+
+Deno.test('signal() should support derived function values', () => {
+  const counter = signal(0);
+  const doubleCounter = () => counter() * 2;
+
+  expect(doubleCounter()).toBe(0);
+
+  counter.set(1);
+
+  expect(doubleCounter()).toBe(2);
+});
+
+Deno.test('signal() should remain readable when passed as a function parameter', () => {
+  const firstName = signal('Alice');
+  const lastName = signal('Smith');
+
+  type Signals = {
+    firstName: WritableSignal<string>;
+    lastName: WritableSignal<string>;
+  };
+
+  const buildDisplayName = ({ firstName, lastName }: Signals) => `${firstName()} ${lastName()}`;
+
+  const displayName = () => buildDisplayName({ firstName, lastName });
+
+  expect(displayName()).toBe('Alice Smith');
+
+  firstName.set('Bob');
+
+  expect(displayName()).toBe('Bob Smith');
+});
+
+Deno.test('WritableSignal.untracked() should not track dependencies', () => {
+  const changes: number[] = [];
+
+  const counter = signal(0);
+  const readonlyCounter = counter.readonly();
+
+  effect(() => {
+    changes.push(counter.untracked());
+    changes.push(readonlyCounter.untracked());
   });
 
-  test('should allow to update a signal value', () => {
-    const counter = signal(0);
+  counter.set(1);
 
-    counter.update((value) => value + 1);
+  expect(changes).toStrictEqual([]);
 
-    expect(counter()).toBe(1);
-  });
+  counter.set(2);
 
-  test('should allow to mutate a signal value', () => {
-    const user = signal<TestingUser>({ name: 'Alice', age: 42 });
+  expect(changes).toStrictEqual([]);
+});
 
-    user.mutate((value) => {
-      value.name = 'Bob';
+Deno.test('signal() should update its value from configured events', () => {
+  using counter = signal(0, { allowEvents: true });
+
+  expect(counter()).toBe(0);
+
+  dispatchEvent(new CustomEvent(counter.identifier, { detail: 1 }));
+
+  expect(counter()).toBe(1);
+});
+
+Deno.test('WritableEventSignal[Symbol.dispose]() should remove its event listener', () => {
+  const changes: number[] = [];
+
+  {
+    using counter = signal(0, {
+      name: 'counter_test_2',
+      allowEvents: true,
+      subscribe: (value) => changes.push(value),
     });
-
-    expect(user().name).toBe('Bob');
-  });
-
-  test('should create a readonly signal', () => {
-    const value = signal(0).readonly();
-
-    expect(value()).toBe(0);
-
-    const signalFnKeys = Object.keys(value);
-    const writableKeys = signalFnKeys.find((key) =>
-      key === 'set' || key === 'update' || key === 'mutate'
-    );
-
-    expect(writableKeys).toBe(undefined);
-  });
-
-  test('should subscribe to readonly signals', () => {
-    const privateCounter = signal(0);
-
-    const counter = {
-      mutable: privateCounter,
-      readonly: privateCounter.readonly(),
-    };
-
-    expect(counter.readonly()).toBe(0);
-
-    const signalFnKeys = Object.keys(counter.readonly);
-    const writableKeys = signalFnKeys.find((key) =>
-      key === 'set' || key === 'update' || key === 'mutate'
-    );
-
-    expect(writableKeys).toBe(undefined);
-
-    privateCounter.set(1);
-    expect(counter.readonly()).toBe(1);
-
-    counter.mutable.set(2);
-    expect(counter.readonly()).toBe(2);
-  });
-
-  test('should allow to use `subscribe` hook', () => {
-    const called = [] as number[];
-
-    const counter = signal(0, {
-      subscribe: (value) => called.push(value),
-    });
-
-    expect(called).toStrictEqual([]);
-
-    counter.set(1);
-    expect(called).toStrictEqual([1]);
-
-    counter.set(23);
-    expect(called).toStrictEqual([1, 23]);
-
-    counter.set(23);
-    expect(called).toStrictEqual([1, 23]);
-  });
-
-  test('should allow to use computed values', () => {
-    const counter = signal(0);
-    const doubleCounter = () => counter() * 2;
-
-    expect(doubleCounter()).toBe(0);
-
-    counter.set(1);
-
-    expect(doubleCounter()).toBe(2);
-  });
-
-  test('should allow to pass signals as params and subscribe to changes', () => {
-    const firstName = signal('Alice');
-    const lastName = signal('Smith');
-
-    type Signals = {
-      firstName: WritableSignal<string>;
-      lastName: WritableSignal<string>;
-    };
-
-    const buildDisplayName = ({ firstName, lastName }: Signals) => `${firstName()} ${lastName()}`;
-
-    const displayName = () => buildDisplayName({ firstName, lastName });
-
-    expect(displayName()).toBe('Alice Smith');
-
-    firstName.set('Bob');
-
-    expect(displayName()).toBe('Bob Smith');
-  });
-
-  test('should not track changes in untracked blocks', () => {
-    const changes: number[] = [];
-
-    const counter = signal(0);
-    const readonlyCounter = counter.readonly();
-
-    effect(() => {
-      changes.push(counter.untracked());
-      changes.push(readonlyCounter.untracked());
-    });
-
-    counter.set(1);
 
     expect(changes).toStrictEqual([]);
-
-    counter.set(2);
-
-    expect(changes).toStrictEqual([]);
-  });
-
-  test('should allow to update values using events', () => {
-    using counter = signal(0, { allowEvents: true });
-
     expect(counter()).toBe(0);
 
-    dispatchEvent(new CustomEvent(counter.identifier, { detail: 1 }));
+    dispatchEvent(new CustomEvent('counter_test_2', { detail: 1 }));
 
-    expect(counter()).toBe(1);
-  });
-
-  test('should clean up listener after signal is out of scope', () => {
-    const changes: number[] = [];
-
-    {
-      using counter = signal(0, {
-        name: 'counter_test_2',
-        allowEvents: true,
-        subscribe: (value) => changes.push(value),
-      });
-
-      expect(changes).toStrictEqual([]);
-      expect(counter()).toBe(0);
-
-      dispatchEvent(new CustomEvent('counter_test_2', { detail: 1 }));
-
-      expect(changes).toStrictEqual([1]);
-      expect(counter()).toBe(1);
-    }
-
-    dispatchEvent(new CustomEvent('counter_test_2', { detail: 2 }));
     expect(changes).toStrictEqual([1]);
+    expect(counter()).toBe(1);
+  }
+
+  dispatchEvent(new CustomEvent('counter_test_2', { detail: 2 }));
+  expect(changes).toStrictEqual([1]);
+});
+
+Deno.test('WritableSignal.readonly() should create a distinct identifier', () => {
+  const counter = signal(0, { name: 'counter' });
+  const readonlyCounter = counter.readonly();
+
+  expect(counter.identifier).not.toBe(readonlyCounter.identifier);
+});
+
+Deno.test('signal() should log changes', () => {
+  using consoleStub = stub(console, 'log', (_) => {});
+
+  const hello = signal({ hello: 'world' }, { name: 'hello', log: true });
+
+  hello.set({ hello: 'world set' });
+  hello.mutate((value) => {
+    value.hello = 'world mutate';
   });
 
-  test('should create a new identifier for a readonly signal', () => {
-    const counter = signal(0, { name: 'counter' });
-    const readonlyCounter = counter.readonly();
+  assertSpyCalls(consoleStub, 6); // 6 calls since each log is called 3 times.
+});
 
-    expect(counter.identifier).not.toBe(readonlyCounter.identifier);
-  });
-
-  test('should log changes', () => {
-    using consoleStub = stub(console, 'log', (_) => {});
-
-    const hello = signal({ hello: 'world' }, { name: 'hello', log: true });
-
-    hello.set({ hello: 'world set' });
-    hello.mutate((value) => {
-      value.hello = 'world mutate';
-    });
-
-    assertSpyCalls(consoleStub, 6); // 6 calls since each log is called 3 times.
-  });
-
-  test('should have a toString implementation', () => {
-    const counter = signal(1);
-    expect(counter + '').toBe('[Signal: 1]');
-  });
+Deno.test('WritableSignal.toString() should return its string representation', () => {
+  const counter = signal(1);
+  expect(counter + '').toBe('[Signal: 1]');
 });

--- a/module/store.ts
+++ b/module/store.ts
@@ -121,7 +121,7 @@ export function store<T extends ValidStore>(initializeStoreValues: StoreValues<T
 
     const signalConfig = {
       ...(isConfigured && stateValue.name && { name: stateValue.name }),
-      ...(isConfigured && stateValue.log && { log: stateValue.log }),
+      ...(isConfigured && stateValue.log !== undefined && { log: stateValue.log }),
       ...(isConfigured && stateValue.equal && { equal: stateValue.equal }),
       ...(isConfigured && stateValue.subscribe && { subscribe: stateValue.subscribe }),
     } as SignalOptions<T>;
@@ -143,7 +143,7 @@ export function store<T extends ValidStore>(initializeStoreValues: StoreValues<T
   function useStore<U extends (keyof T)>(): ReadonlyState<T>[U];
   function useStore(): ReadonlyState<T>;
   function useStore<U extends (keyof T)>(selector?: U): ReadonlyState<T>[U] | ReadonlyState<T> {
-    return selector ? immutableState[selector] : immutableState;
+    return selector === undefined ? immutableState : immutableState[selector];
   }
 
   return useStore;

--- a/module/store_test.ts
+++ b/module/store_test.ts
@@ -1,24 +1,23 @@
 // Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
 
-import { describe as group, test } from '@std/testing/bdd';
 import { assertSpyCalls, stub } from '@std/testing/mock';
 import { expect } from '@std/expect';
 
 import { delay } from '@std/async/delay';
 
-import { store } from './store.ts';
+import { type Store, store } from './store.ts';
 
-group('reactive / store()', () => {
-  type CounterStore = {
-    count: number;
-    increment: () => void;
-    decrement: () => void;
-    reset: () => void;
-    doubleCount: number;
-    name: string;
-  };
+type CounterStore = {
+  count: number;
+  increment: () => void;
+  decrement: () => void;
+  reset: () => void;
+  doubleCount: number;
+  name: string;
+};
 
-  const counterStore = store<CounterStore>(({ get }) => ({
+function createCounterStore(): Store<CounterStore> {
+  return store<CounterStore>(({ get }) => ({
     count: 0,
     increment: () => get().count.update((count) => count + 1),
     decrement: () => get().count.update((count) => count - 1),
@@ -30,162 +29,170 @@ group('reactive / store()', () => {
       value: 'Counter',
     },
   }));
+}
 
-  test('should create basic store and access values, actions and computed values', () => {
-    const counter = counterStore();
+Deno.test('store() should expose values, actions, and computed values', () => {
+  const counterStore = createCounterStore();
+  const counter = counterStore();
 
-    expect(counter.count()).toBe(0);
+  expect(counter.count()).toBe(0);
 
-    counter.increment();
-    expect(counter.count()).toBe(1);
+  counter.increment();
+  expect(counter.count()).toBe(1);
 
-    counter.decrement();
-    expect(counter.count()).toBe(0);
+  counter.decrement();
+  expect(counter.count()).toBe(0);
 
-    counter.increment();
-    counter.increment();
-    expect(counter.count()).toBe(2);
-    expect(counter.doubleCount()).toBe(4);
+  counter.increment();
+  counter.increment();
+  expect(counter.count()).toBe(2);
+  expect(counter.doubleCount()).toBe(4);
 
-    counter.reset();
-    expect(counter.count()).toBe(0);
+  counter.reset();
+  expect(counter.count()).toBe(0);
 
-    expect(counter.name()).toBe('Counter');
-  });
+  expect(counter.name()).toBe('Counter');
+});
 
-  test('should allow to configure signals', () => {
-    using consoleStub = stub(console, 'log', (_) => {});
-    const changes: number[] = [];
+Deno.test('store() should apply signal configuration', () => {
+  using consoleStub = stub(console, 'log', (_) => {});
+  const changes: number[] = [];
 
-    const configuredCounterStore = store<CounterStore>(({ get }) => ({
-      name: 'Counter',
-      count: {
-        value: 0,
-        name: 'count',
-        log: true,
-        equal: (a, b) => a === b,
-        subscribe: (value) => changes.push(value),
-      },
-      increment: () => get().count.update((count) => count + 1),
-      decrement: () => get().count.update((count) => count - 1),
-      reset: () => get().count.set(0),
-      doubleCount: { value: () => get().count() * 2 },
-    }));
+  const configuredCounterStore = store<CounterStore>(({ get }) => ({
+    name: 'Counter',
+    count: {
+      value: 0,
+      name: 'count',
+      log: true,
+      equal: (a, b) => a === b,
+      subscribe: (value) => changes.push(value),
+    },
+    increment: () => get().count.update((count) => count + 1),
+    decrement: () => get().count.update((count) => count - 1),
+    reset: () => get().count.set(0),
+    doubleCount: { value: () => get().count() * 2 },
+  }));
 
-    const counter = configuredCounterStore();
+  const counter = configuredCounterStore();
 
-    counter.increment();
-    counter.increment();
-    counter.increment();
+  counter.increment();
+  counter.increment();
+  counter.increment();
 
-    expect(changes).toStrictEqual([1, 2, 3]);
-    assertSpyCalls(consoleStub, 9); // 9 calls since each log is called 3 times.
-  });
+  expect(changes).toStrictEqual([1, 2, 3]);
+  assertSpyCalls(consoleStub, 9); // 9 calls since each log is called 3 times.
+});
 
-  test('should allow using the selector to access specific store values and actions', () => {
-    const count = counterStore('count');
-    const increment = counterStore('increment');
+Deno.test('store() should return a specific value or action when given a selector', () => {
+  const counterStore = createCounterStore();
+  const count = counterStore('count');
+  const increment = counterStore('increment');
 
-    expect(count()).toBe(0);
+  expect(count()).toBe(0);
 
-    increment();
-    expect(count()).toBe(1);
+  increment();
+  expect(count()).toBe(1);
 
-    increment();
-    expect(count()).toBe(2);
-  });
+  increment();
+  expect(count()).toBe(2);
+});
 
-  test('should allow to use promises', async () => {
-    type User = {
-      uid: string;
-      username: string;
-      password: string;
-    };
+Deno.test('store() should select values with an empty string key', () => {
+  const valueStore = store<{ '': number }>(() => ({ '': 42 }));
 
-    const mockedUsers: User[] = [];
+  expect(valueStore('')()).toBe(42);
+});
 
-    const UserService = {
-      create: async (username: string, password: string) => {
-        await delay(5);
-        const user = { uid: `${mockedUsers.length + 1}`, username, password };
-        mockedUsers.push(user);
-        return user;
-      },
-      read: async (username: string) => {
-        await delay(5);
-        const user = mockedUsers.find((user) => user.username === username);
-        return user ?? null;
-      },
-      update: async (uid: string, username: string, password: string) => {
-        await delay(5);
-        const user = mockedUsers.find((user) => user.uid === uid);
-        if (user) {
-          user.username = username;
-          user.password = password;
-        }
-        return user ?? null;
-      },
-      delete: async (uid: string) => {
-        await delay(5);
-        const user = mockedUsers.find((user) => user.uid === uid);
-        if (user) {
-          mockedUsers.splice(mockedUsers.indexOf(user), 1);
-        }
-        return user ?? null;
-      },
-    };
+Deno.test('store() should support asynchronous actions', async () => {
+  type User = {
+    uid: string;
+    username: string;
+    password: string;
+  };
 
-    type AuthStore = {
-      user: User | null;
-      uid: string | null;
-      signUp: (username: string, password: string) => Promise<User>;
-      signIn: (username: string, password: string) => Promise<User | null>;
-      signOut: () => Promise<boolean>;
-    };
+  const mockedUsers: User[] = [];
 
-    const authenticationStore = store<AuthStore>(({ get }) => ({
-      user: null,
-      uid: {
-        value: () => get().user()?.uid ?? null, // uid is a derived value from user.
-      },
-      signIn: async (username, password) => {
-        const userSignedIn = await UserService.read(username);
-        if (userSignedIn?.password !== password) {
-          get().user.set(null);
-          return null;
-        }
-        get().user.set(userSignedIn);
-        return userSignedIn;
-      },
-      signOut: async () => {
-        await delay(5);
+  const UserService = {
+    create: async (username: string, password: string) => {
+      await delay(5);
+      const user = { uid: `${mockedUsers.length + 1}`, username, password };
+      mockedUsers.push(user);
+      return user;
+    },
+    read: async (username: string) => {
+      await delay(5);
+      const user = mockedUsers.find((user) => user.username === username);
+      return user ?? null;
+    },
+    update: async (uid: string, username: string, password: string) => {
+      await delay(5);
+      const user = mockedUsers.find((user) => user.uid === uid);
+      if (user) {
+        user.username = username;
+        user.password = password;
+      }
+      return user ?? null;
+    },
+    delete: async (uid: string) => {
+      await delay(5);
+      const user = mockedUsers.find((user) => user.uid === uid);
+      if (user) {
+        mockedUsers.splice(mockedUsers.indexOf(user), 1);
+      }
+      return user ?? null;
+    },
+  };
+
+  type AuthStore = {
+    user: User | null;
+    uid: string | null;
+    signUp: (username: string, password: string) => Promise<User>;
+    signIn: (username: string, password: string) => Promise<User | null>;
+    signOut: () => Promise<boolean>;
+  };
+
+  const authenticationStore = store<AuthStore>(({ get }) => ({
+    user: null,
+    uid: {
+      value: () => get().user()?.uid ?? null, // uid is a derived value from user.
+    },
+    signIn: async (username, password) => {
+      const userSignedIn = await UserService.read(username);
+      if (userSignedIn?.password !== password) {
         get().user.set(null);
-        return true;
-      },
-      signUp: async (username, password) => {
-        const newUser = await UserService.create(username, password);
+        return null;
+      }
+      get().user.set(userSignedIn);
+      return userSignedIn;
+    },
+    signOut: async () => {
+      await delay(5);
+      get().user.set(null);
+      return true;
+    },
+    signUp: async (username, password) => {
+      const newUser = await UserService.create(username, password);
 
-        get().user.set(newUser);
+      get().user.set(newUser);
 
-        return newUser;
-      },
-    }));
+      return newUser;
+    },
+  }));
 
-    const auth = authenticationStore();
-    expect(auth.uid()).toBe(null);
+  const auth = authenticationStore();
+  expect(auth.uid()).toBe(null);
 
-    await auth.signUp('username', 'password');
-    expect(auth.uid()).toBe('1');
+  await auth.signUp('username', 'password');
+  expect(auth.uid()).toBe('1');
 
-    await auth.signOut();
-    expect(auth.uid()).toBe(null);
+  await auth.signOut();
+  expect(auth.uid()).toBe(null);
 
-    await auth.signIn('username', 'password');
-    expect(auth.uid()).toBe('1');
-    expect(auth.user()).toStrictEqual({ uid: '1', username: 'username', password: 'password' });
+  await auth.signIn('username', 'password');
+  expect(auth.uid()).toBe('1');
+  expect(auth.user()).toStrictEqual({ uid: '1', username: 'username', password: 'password' });
 
-    await auth.signOut();
-    expect(auth.uid()).toBe(null);
-    expect(auth.user()).toBe(null);
-  });
+  await auth.signOut();
+  expect(auth.uid()).toBe(null);
+  expect(auth.user()).toBe(null);
 });

--- a/module/to_signal_test.ts
+++ b/module/to_signal_test.ts
@@ -1,33 +1,30 @@
 // Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
 
-import { describe as group, test } from '@std/testing/bdd';
 import { expect } from '@std/expect';
 
 import { delay } from '@std/async';
 
 import { toSignal } from './to_signal.ts';
 
-group('reactive / toSignal()', () => {
-  test('should create a signal from a promise function', async () => {
-    const promise1 = toSignal(() => delay(10).then(() => 'Hello, World!'));
-    const promise2 = toSignal(delay(10).then(() => 'Hello, World!'));
+Deno.test('toSignal() should create signals from promises and promise functions', async () => {
+  const promise1 = toSignal(() => delay(10).then(() => 'Hello, World!'));
+  const promise2 = toSignal(delay(10).then(() => 'Hello, World!'));
 
-    expect(promise1()).toStrictEqual({ status: 'pending' });
-    expect(promise2()).toStrictEqual({ status: 'pending' });
+  expect(promise1()).toStrictEqual({ status: 'pending' });
+  expect(promise2()).toStrictEqual({ status: 'pending' });
 
-    await delay(20);
+  await delay(20);
 
-    expect(promise1()).toStrictEqual({ status: 'fulfilled', value: 'Hello, World!' });
-    expect(promise2()).toStrictEqual({ status: 'fulfilled', value: 'Hello, World!' });
-  });
+  expect(promise1()).toStrictEqual({ status: 'fulfilled', value: 'Hello, World!' });
+  expect(promise2()).toStrictEqual({ status: 'fulfilled', value: 'Hello, World!' });
+});
 
-  test('should return errors rejected by the promise', async () => {
-    const promise = toSignal(() => delay(10).then(() => Promise.reject('Error!')));
+Deno.test('toSignal() should expose rejected promise errors', async () => {
+  const promise = toSignal(() => delay(10).then(() => Promise.reject('Error!')));
 
-    expect(promise()).toStrictEqual({ status: 'pending' });
+  expect(promise()).toStrictEqual({ status: 'pending' });
 
-    await delay(20);
+  await delay(20);
 
-    expect(promise()).toStrictEqual({ status: 'rejected', error: 'Error!' });
-  });
+  expect(promise()).toStrictEqual({ status: 'rejected', error: 'Error!' });
 });

--- a/module/untracked_test.ts
+++ b/module/untracked_test.ts
@@ -1,28 +1,25 @@
 // Copyright the Deft+ authors. All rights reserved. Apache-2.0 license
 
-import { describe as group, test } from '@std/testing/bdd';
 import { expect } from '@std/expect';
 
 import { untrackedSignal } from './untracked.ts';
 import { signal } from './signal.ts';
 import { effect } from './effect.ts';
 
-group('reactive / createUntrackedSignal()', () => {
-  test('should not track changes in untracked blocks', () => {
-    const changes: number[] = [];
+Deno.test('untrackedSignal() should read without tracking dependencies', () => {
+  const changes: number[] = [];
 
-    const counter = signal(0);
+  const counter = signal(0);
 
-    effect(() => {
-      changes.push(untrackedSignal(() => counter()));
-    });
-
-    counter.set(1);
-
-    expect(changes).toStrictEqual([]);
-
-    counter.set(2);
-
-    expect(changes).toStrictEqual([]);
+  effect(() => {
+    changes.push(untrackedSignal(() => counter()));
   });
+
+  counter.set(1);
+
+  expect(changes).toStrictEqual([]);
+
+  counter.set(2);
+
+  expect(changes).toStrictEqual([]);
 });

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "deno": {
+      "source": "denoland/skills",
+      "sourceType": "github",
+      "skillPath": "skills/deno/SKILL.md",
+      "computedHash": "ac6e73271ee74ee92ee995bcd99661da6d8ad5280d90aee637b53267f6d3fbb7"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR improves the project’s Deno configuration, fixes several reactive API edge cases, modernizes the test suite, and reaches 100% branch, function, and line coverage.

The main changes include:

- Configure the project and CI for Deno 2.9.
- Add reproducible dependency locking and update dependencies.
- Add Deno development instructions and project guidance in `AGENTS.md`.
- Add optional global signal logging through `SIGNAL_LOG=true`.
  - Explicit `log` options take precedence.
  - Missing environment permissions do not break the library.
  - Unsupported runtimes safely default to disabled logging.
- Migrate the test suite from `@std/testing/bdd` to independent top-level `Deno.test()` cases.
- Standardize test names using `<function-or-method>() <behavior>`.
- Fix `effect.initial()` executing twice during initialization.
- Make effect destruction idempotent so cleanup runs only once.
- Fix `isSignal(undefined)` throwing instead of returning `false`.
- Add the missing runtime identifier to memoized signals.
- Fix store selectors for falsy keys such as an empty string.
- Expand tests around dependency tracking, stale dependency cleanup, notification safety, logging permissions, and unchanged effect dependencies.
- Enforce 100% branch, function, and line coverage in the test tasks.
- Make `effect.resetEffects()` destroy every active effect and run its cleanup callback exactly once.
- Complete the exported `LogConfig` API documentation.
- Ensure documentation lint passes.

The test suite now contains 60 passing tests and reports:

- 100% branch coverage
- 100% function coverage
- 100% line coverage

The `test` and `test:u` tasks enforce a 100% coverage threshold to prevent future regressions.

The non-Deno logging fallback is excluded using Deno’s official coverage directive because the Deno test runner cannot execute without the `Deno` global. Permission-denied and explicit logging behavior remain fully tested.

#### This bumps to version 1.0.0

## Checklist before requesting a review

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).